### PR TITLE
update readme and fix function name typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,21 @@ Import and sync IMDb lists to TMDB
 
 ## Setup
 
-1. Make sure you have [Node.js](https://nodejs.org/) installed. You can use [Bun.js](https://bun.sh/) too.
+1. Make sure you have [Node.js](https://nodejs.org/) v18+ installed. You can use [Bun.js](https://bun.sh/) too.
 
 2. [Download this repo](https://github.com/Tetrax-10/import-imdb-lists-to-tmdb/archive/refs/heads/main.zip).
 
 3. Open a terminal inside `import-imdb-lists-to-tmdb` folder and run `npm install`.
 
-4. Rename the file `.env.example` to `.env` and replace the placeholders with your api key and WRITE access token.
+4. Create a [TMDB API application](https://www.themoviedb.org/settings/api).
 
-    **Note**: You should create a write access token if you don't have one in-order for this tool to work. Create it from [here](http://dev.travisbell.com/play/v4_auth.html) with your [API Read Access Token](https://www.themoviedb.org/settings/api).
+5. Generate your WRITE access token
+    1. Copy the API Read Access Token from step 4 and paste it into the input [here](http://dev.travisbell.com/play/v4_auth.html)
+    2. Click "Get Request Token"
+    3. Click "Approve Token" (this will open a new tab where you will click Approve)
+    4. Click "Get Access Token"
+
+6. Rename the file `.env.example` to `.env` and replace the placeholders with your api key from your [TMDB API application](https://www.themoviedb.org/settings/api) and WRITE access token generated in step 5.
 
 </br>
 

--- a/src/import.js
+++ b/src/import.js
@@ -4,7 +4,7 @@ import path from "path"
 import { downloadImdbListCsv } from "./utils/imdbListCsvDownloader.js"
 import { csvToJson, wait, printLine, clearLastLine } from "./utils/utils.js"
 import { getFileContents, getJsonContents, copyFile, writeJSON, fsExsists } from "./utils/glob.js"
-import { addTitlesToTmdbList, clearTmdbList, creteTmdbList, fetchTmdbIdsFromImdbIds, fetchTmdbListDetails } from "./utils/tmdbApiHelper.js"
+import { addTitlesToTmdbList, clearTmdbList, createTmdbList, fetchTmdbIdsFromImdbIds, fetchTmdbListDetails } from "./utils/tmdbApiHelper.js"
 
 const CONFIG = getJsonContents("./config.json")
 
@@ -39,7 +39,7 @@ async function importLists() {
 
         if (isNewList) {
             // create tmdb list for new imdb list
-            tmdbListId = await creteTmdbList(imdbListName)
+            tmdbListId = await createTmdbList(imdbListName)
 
             if (!tmdbListId) {
                 clearLastLine()
@@ -130,7 +130,7 @@ async function importLists() {
         // sort imdb list
         if (!isTmdbListUpdatable) {
             clearLastLine()
-            printLine(chalk.yellow(`${isNewList ? "Creating" : "Force Syncing"}: ${imdbListName}`))
+            printLine(chalk.yellow(`${isNewList ? "Creating" : "Force Syncing"}: ${imdbListName}\n`))
 
             // wait for 5 secs for TMDB to process
             await wait(5000)

--- a/src/utils/tmdbApiHelper.js
+++ b/src/utils/tmdbApiHelper.js
@@ -68,7 +68,7 @@ export async function fetchTmdbListDetails(tmdbListId) {
     }
 }
 
-export async function creteTmdbList(name) {
+export async function createTmdbList(name) {
     try {
         const response = await fetch("https://api.themoviedb.org/4/list", {
             method: "POST",


### PR DESCRIPTION
- Fix function name typo `creteTmdbList` --> `createTmdbList`
- Add more detail to README.md on how to generate the WRITE access token
- Specify minimum node version to have installed (otherwise you get errors about `fetch` since it wasn't included in node until 18+)